### PR TITLE
Fix typo 'algorhitms'

### DIFF
--- a/extensions/spellcheck/hunspell/tests/unit/data/suggestiontest/List_of_common_misspellings.txt
+++ b/extensions/spellcheck/hunspell/tests/unit/data/suggestiontest/List_of_common_misspellings.txt
@@ -201,7 +201,7 @@ alege	allege
 aleged	alleged
 alegience	allegiance
 algebraical	algebraic
-algorhitms	algorithms
+algorithms	algorithms
 algoritm	algorithm
 algoritms	algorithms
 alientating	alienating


### PR DESCRIPTION
```
Hi! I'm a bot that checks GitHub for spelling mistakes, and I found one in your repository. When it
should be 'algorithms', you typed 'algorhitms'. I created this pull request to fix it!

If you think there is anything wrong with this pull request or just have a question, be kind to mail me 
at thetypomaster@hotmail.com (professional email, huh?). I’ll try to address the problem as soon as
I’m aware of it.

Looking for the source code of this bot? Well, you have to be patient! The bot is under development
and I will publish the source code as soon as I’m finished with it.

If you decide to close this pull request, pleace specify why before doing so.

With kind regards,
TheTypoMaster
```
